### PR TITLE
 Use service-network 3.1.2

### DIFF
--- a/src/pytest_infrahouse/data/service-network/locals.tf
+++ b/src/pytest_infrahouse/data/service-network/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  last_az_idx = length(data.aws_availability_zones.available.names) - 1
+}

--- a/src/pytest_infrahouse/data/service-network/main.tf
+++ b/src/pytest_infrahouse/data/service-network/main.tf
@@ -1,6 +1,6 @@
 module "service-network" {
   source                = "registry.infrahouse.com/infrahouse/service-network/aws"
-  version               = "~> 2.3"
+  version               = "3.1.2"
   service_name          = "service-network"
   vpc_cidr_block        = "10.1.0.0/16"
   management_cidr_block = "10.1.0.0/16"
@@ -18,17 +18,14 @@ module "service-network" {
       cidr                    = "10.1.1.0/24"
       availability-zone       = data.aws_availability_zones.available.names[1]
       map_public_ip_on_launch = true
-      create_nat              = true
+      create_nat              = false
       forward_to              = null
     },
     {
       cidr = "10.1.2.0/24"
-      availability-zone = element(
-        data.aws_availability_zones.available.names,
-        length(data.aws_availability_zones.available.names) - 1
-      )
+      availability-zone = data.aws_availability_zones.available.names[local.last_az_idx]
       map_public_ip_on_launch = true
-      create_nat              = true
+      create_nat              = false
       forward_to              = null
     },
     {
@@ -43,17 +40,14 @@ module "service-network" {
       availability-zone       = data.aws_availability_zones.available.names[1]
       map_public_ip_on_launch = false
       create_nat              = false
-      forward_to              = "10.1.1.0/24"
+      forward_to              = "10.1.0.0/24"  # to a network with NAT
     },
     {
       cidr = "10.1.102.0/24"
-      availability-zone = element(
-        data.aws_availability_zones.available.names,
-        length(data.aws_availability_zones.available.names) - 1
-      )
+      availability-zone = data.aws_availability_zones.available.names[local.last_az_idx]
       map_public_ip_on_launch = false
       create_nat              = false
-      forward_to              = "10.1.2.0/24"
+      forward_to              = "10.1.0.0/24"  # to a network with NAT
     }
   ]
 }


### PR DESCRIPTION
The 3.1.2 version allows using only one NAT gateway

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Upgrade the `service-network` module version to 3.1.2, replace availability zone calculation with a local variable, change NAT settings to `false`, and update subnet forwarding addresses.

### Why are these changes being made?

The change to version 3.1.2 was necessary to leverage the latest functionalities and improvements in the service-network module. This includes using a local variable to optimize availability zone index calculations and setting `create_nat` to `false` to improve network configuration consistency. Updating the `forward_to` addresses ensures proper routing to a network with NAT, aligning with recent infrastructure requirements.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->