### PR TITLE
Add vpc_id output to service-network fixture

### DIFF
--- a/src/pytest_infrahouse/data/service-network/outputs.tf
+++ b/src/pytest_infrahouse/data/service-network/outputs.tf
@@ -9,3 +9,7 @@ output "subnet_private_ids" {
 output "internet_gateway_id" {
   value = module.service-network.internet_gateway_id
 }
+
+output "vpc_id" {
+  value = module.service-network.vpc_id
+}


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add `vpc_id` output to the `service-network` fixture in the Terraform outputs configuration.

### Why are these changes being made?

The addition of the `vpc_id` output allows users to access the VPC ID directly, enhancing the usability of the `service-network` fixture in testing and automation scenarios. This change facilitates better management and reference of network infrastructure elements, aligning with the requirements for increased visibility and access to network components within the infrastructure.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->