### PR TITLE
Add subzone fixture for DNS testing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,7 @@ Features
   * ``elasticsearch`` - Elasticsearch cluster setup
   * ``ses`` - Simple Email Service configuration
   * ``probe_role`` - IAM role with limited permissions
+  * ``subzone`` - Route53 DNS subzone for testing
 
 * **Terraform Integration**: Seamless integration with Terraform via ``terraform_apply`` context manager
 * **Resource Management**: Automatic cleanup of AWS resources after tests (configurable)
@@ -134,6 +135,7 @@ Available Fixtures
 * ``elasticsearch`` - Elasticsearch cluster
 * ``ses`` - Simple Email Service setup
 * ``probe_role`` - IAM role with limited permissions
+* ``subzone`` - Route53 DNS subzone for testing
 
 **Configuration Fixtures:**
 

--- a/src/pytest_infrahouse/data/subzone/datasources.tf
+++ b/src/pytest_infrahouse/data/subzone/datasources.tf
@@ -1,0 +1,3 @@
+data "aws_route53_zone" "parent" {
+  name = var.parent_zone_name
+}

--- a/src/pytest_infrahouse/data/subzone/dns.tf
+++ b/src/pytest_infrahouse/data/subzone/dns.tf
@@ -1,0 +1,18 @@
+resource "random_string" "subdomain" {
+  length  = 6
+  numeric = false
+  special = false
+  upper   = false
+}
+
+resource "aws_route53_zone" "subzone" {
+  name = "${random_string.subdomain.result}.${data.aws_route53_zone.parent.name}"
+}
+
+resource "aws_route53_record" "subzone_ns" {
+  name    = aws_route53_zone.subzone.name
+  type    = "NS"
+  zone_id = data.aws_route53_zone.parent.zone_id
+  ttl     = 172800
+  records = aws_route53_zone.subzone.name_servers
+}

--- a/src/pytest_infrahouse/data/subzone/outputs.tf
+++ b/src/pytest_infrahouse/data/subzone/outputs.tf
@@ -1,0 +1,4 @@
+output "subzone_id" {
+  description = "Route53 hosted zone ID of the created subzone"
+  value = aws_route53_zone.subzone.zone_id
+}

--- a/src/pytest_infrahouse/data/subzone/outputs.tf
+++ b/src/pytest_infrahouse/data/subzone/outputs.tf
@@ -1,4 +1,4 @@
 output "subzone_id" {
   description = "Route53 hosted zone ID of the created subzone"
-  value = aws_route53_zone.subzone.zone_id
+  value       = aws_route53_zone.subzone.zone_id
 }

--- a/src/pytest_infrahouse/data/subzone/providers.tf
+++ b/src/pytest_infrahouse/data/subzone/providers.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region = var.region
+  dynamic "assume_role" {
+    for_each = var.role_arn != null ? [1] : []
+    content {
+      role_arn = var.role_arn
+    }
+  }
+  default_tags {
+    tags = {
+      created_by : var.calling_test
+      created_by_fixture : "infrahouse/pytest-infrahouse/subzone"
+    }
+  }
+}

--- a/src/pytest_infrahouse/data/subzone/terraform.tf
+++ b/src/pytest_infrahouse/data/subzone/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  //noinspection HILUnresolvedReference
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.11, < 7.0"
+    }
+  }
+}

--- a/src/pytest_infrahouse/data/subzone/variables.tf
+++ b/src/pytest_infrahouse/data/subzone/variables.tf
@@ -1,0 +1,6 @@
+variable "region" {}
+variable "role_arn" {
+  default = null
+}
+variable "parent_zone_name" {}
+variable "calling_test" {}


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a `subzone` fixture to create a Route53 DNS subzone for testing and update the documentation to reflect the addition.

### Why are these changes being made?

The change is aimed at enhancing the DNS testing capabilities by creating isolated subzones which aid in development and testing environments without affecting production zones. The addition of a fixture for DNS subzones allows for better testing infrastructure and automation, enabling parallel tests and reducing the risk of DNS conflicts. Additionally, the `Configure AWS Credentials` GitHub Action was reverted to version 4 for compatibility reasons.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->