### PR TITLE
Upgrade elasticsearch fixture module to 3.10.0 to support aws v6

### DIFF
--- a/src/pytest_infrahouse/data/elasticsearch/main.tf
+++ b/src/pytest_infrahouse/data/elasticsearch/main.tf
@@ -1,6 +1,6 @@
 module "elasticsearch" {
   source  = "registry.infrahouse.com/infrahouse/elasticsearch/aws"
-  version = "~> 3.1, >= 3.1.2"
+  version = "3.10.0"
   providers = {
     aws     = aws
     aws.dns = aws

--- a/src/pytest_infrahouse/data/elasticsearch/terraform.tf
+++ b/src/pytest_infrahouse/data/elasticsearch/terraform.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.11"
+      version = ">= 5.11, < 7.0"
     }
-    cloudinit = {
-      source  = "hashicorp/cloudinit"
-      version = "~> 2.3"
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.1"
     }
   }
 }


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Upgrade the Elasticsearch fixture module to version 3.10.0 and update Terraform provider constraints for AWS and TLS.

### Why are these changes being made?

The Elasticsearch module is being upgraded to version 3.10.0 to ensure compatibility with AWS version 6. The provider constraints for AWS and TLS are updated to accommodate this upgrade and to support the latest features while ensuring stability and compatibility in the module.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->